### PR TITLE
global: DoMapping

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-# This file is part of es-jsonschema.
-# Copyright (C) 2015 CERN.
+# This file is part of DoMapping.
+# Copyright (C) 2015, 2016 CERN.
 #
-# es-jsonschema is free software; you can redistribute it
+# DoMapping is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
 # published by the Free Software Foundation; either version 2 of the
 # License, or (at your option) any later version.
 #
-# es-jsonschema is distributed in the hope that it will be
+# DoMapping is distributed in the hope that it will be
 # useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 # General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with es-jsonschema; if not, write to the
+# along with DoMapping; if not, write to the
 # Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
 # MA 02111-1307, USA.
 #

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-# This file is part of es-jsonschema.
-# Copyright (C) 2015 CERN.
+# This file is part of DoMapping.
+# Copyright (C) 2015, 2016 CERN.
 #
-# es-jsonschema is free software; you can redistribute it
+# DoMapping is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
 # published by the Free Software Foundation; either version 2 of the
 # License, or (at your option) any later version.
 #
-# es-jsonschema is distributed in the hope that it will be
+# DoMapping is distributed in the hope that it will be
 # useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 # General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with es-jsonschema; if not, write to the
+# along with DoMapping; if not, write to the
 # Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
 # MA 02111-1307, USA.
 #

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -1,19 +1,19 @@
 ..
-    This file is part of es-jsonschema.
-    Copyright (C) 2015 CERN.
+    This file is part of DoMapping.
+    Copyright (C) 2015, 2016 CERN.
 
-    es-jsonschema is free software; you can redistribute it
+    DoMapping is free software; you can redistribute it
     and/or modify it under the terms of the GNU General Public License as
     published by the Free Software Foundation; either version 2 of the
     License, or (at your option) any later version.
 
-    es-jsonschema is distributed in the hope that it will be
+    DoMapping is distributed in the hope that it will be
     useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
     General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with es-jsonschema; if not, write to the
+    along with DoMapping; if not, write to the
     Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
     MA 02111-1307, USA.
 
@@ -25,7 +25,7 @@
 Authors
 =======
 
-es-jsonschema provides a library and a CLI generating Elasticsearch mappings from json-schemas.
+DoMapping provides a library and a CLI generating Elasticsearch mappings from JSON Schemas.
 
 - Nicolas Harraudeau <nicolas.harraudeau@cern.ch>
 - Sylvain Letreguilly <letreguilly@ill.fr>

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,19 +1,19 @@
 ..
-    This file is part of es-jsonschema.
-    Copyright (C) 2015 CERN.
+    This file is part of DoMapping.
+    Copyright (C) 2015, 2016 CERN.
 
-    es-jsonschema is free software; you can redistribute it
+    DoMapping is free software; you can redistribute it
     and/or modify it under the terms of the GNU General Public License as
     published by the Free Software Foundation; either version 2 of the
     License, or (at your option) any later version.
 
-    es-jsonschema is distributed in the hope that it will be
+    DoMapping is distributed in the hope that it will be
     useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
     General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with es-jsonschema; if not, write to the
+    along with DoMapping; if not, write to the
     Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
     MA 02111-1307, USA.
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -10,7 +10,7 @@ Types of Contributions
 Report Bugs
 ~~~~~~~~~~~
 
-Report bugs at https://github.com/inveniosoftware/es-jsonschema/issues.
+Report bugs at https://github.com/inveniosoftware/domapping/issues.
 
 If you are reporting a bug, please include:
 
@@ -33,15 +33,15 @@ is open to whoever wants to implement it.
 Write Documentation
 ~~~~~~~~~~~~~~~~~~~
 
-es-jsonschema could always use more documentation, whether as part of the
-official es-jsonschema docs, in docstrings, or even on the web in blog posts,
+DoMapping could always use more documentation, whether as part of the
+official DoMapping docs, in docstrings, or even on the web in blog posts,
 articles, and such.
 
 Submit Feedback
 ~~~~~~~~~~~~~~~
 
 The best way to send feedback is to file an issue at
-https://github.com/inveniosoftware/es-jsonschema/issues.
+https://github.com/inveniosoftware/domapping/issues.
 
 If you are proposing a feature:
 
@@ -60,7 +60,7 @@ Ready to contribute? Here's how to set up `invenio` for local development.
 
    .. code-block:: console
 
-      $ git clone git@github.com:your_name_here/es-jsonschema.git
+      $ git clone git@github.com:your_name_here/domapping.git
 
 3. Install your local copy into a virtualenv. Assuming you have
    virtualenvwrapper installed, this is how you set up your fork for local
@@ -68,8 +68,8 @@ Ready to contribute? Here's how to set up `invenio` for local development.
 
    .. code-block:: console
 
-      $ mkvirtualenv es-jsonschema
-      $ cd es-jsonschema/
+      $ mkvirtualenv domapping
+      $ cd domapping/
       $ pip install -e .[all]
 
 4. Create a branch for local development:
@@ -109,5 +109,5 @@ Before you submit a pull request, check that it meets these guidelines:
 2. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring.
 3. The pull request should work for Python 2.7, 3.3, 3.4 and 3.5. Check
-   https://travis-ci.com/inveniosoftware/es-jsonschema/pull_requests
+   https://travis-ci.com/inveniosoftware/domapping/pull_requests
    and make sure that the tests pass for all supported Python versions.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-# This file is part of es-jsonschema.
-# Copyright (C) 2015 CERN.
+# This file is part of DoMapping.
+# Copyright (C) 2015, 2016 CERN.
 #
-# es-jsonschema is free software; you can redistribute it
+# DoMapping is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
 # published by the Free Software Foundation; either version 2 of the
 # License, or (at your option) any later version.
 #
-# es-jsonschema is distributed in the hope that it will be
+# DoMapping is distributed in the hope that it will be
 # useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 # General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with es-jsonschema; if not, write to the
+# along with DoMapping; if not, write to the
 # Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
 # MA 02111-1307, USA.
 #

--- a/README.rst
+++ b/README.rst
@@ -1,19 +1,19 @@
 ..
-    This file is part of es-jsonschema.
-    Copyright (C) 2015 CERN.
+    This file is part of DoMapping.
+    Copyright (C) 2015, 2016 CERN.
 
-    es-jsonschema is free software; you can redistribute it
+    DoMapping is free software; you can redistribute it
     and/or modify it under the terms of the GNU General Public License as
     published by the Free Software Foundation; either version 2 of the
     License, or (at your option) any later version.
 
-    es-jsonschema is distributed in the hope that it will be
+    DoMapping is distributed in the hope that it will be
     useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
     General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with es-jsonschema; if not, write to the
+    along with DoMapping; if not, write to the
     Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
     MA 02111-1307, USA.
 
@@ -21,29 +21,29 @@
     waive the privileges and immunities granted to it by virtue of its status
     as an Intergovernmental Organization or submit itself to any jurisdiction.
 
-===============
- es-jsonschema
-===============
+===========
+ DoMapping
+===========
 
-.. image:: https://img.shields.io/travis/inveniosoftware/es-jsonschema.svg
-        :target: https://travis-ci.org/inveniosoftware/es-jsonschema
+.. image:: https://img.shields.io/travis/inveniosoftware/domapping.svg
+        :target: https://travis-ci.org/inveniosoftware/domapping
 
-.. image:: https://img.shields.io/coveralls/inveniosoftware/es-jsonschema.svg
-        :target: https://coveralls.io/r/inveniosoftware/es-jsonschema
+.. image:: https://img.shields.io/coveralls/inveniosoftware/domapping.svg
+        :target: https://coveralls.io/r/inveniosoftware/domapping
 
-.. image:: https://img.shields.io/github/tag/inveniosoftware/es-jsonschema.svg
-        :target: https://github.com/inveniosoftware/es-jsonschema/releases
+.. image:: https://img.shields.io/github/tag/inveniosoftware/domapping.svg
+        :target: https://github.com/inveniosoftware/domapping/releases
 
-.. image:: https://img.shields.io/pypi/dm/es-jsonschema.svg
-        :target: https://pypi.python.org/pypi/es-jsonschema
+.. image:: https://img.shields.io/pypi/dm/domapping.svg
+        :target: https://pypi.python.org/pypi/domapping
 
-.. image:: https://img.shields.io/github/license/inveniosoftware/es-jsonschema.svg
-        :target: https://github.com/inveniosoftware/es-jsonschema/blob/master/LICENSE
+.. image:: https://img.shields.io/github/license/inveniosoftware/domapping.svg
+        :target: https://github.com/inveniosoftware/domapping/blob/master/LICENSE
 
 
-es-jsonschema provides a library and a CLI generating Elasticsearch mappings from json-schemas.
+DoMapping provides a library and a CLI generating Elasticsearch mappings from JSON Schemas.
 
 *This is an experimental developer preview release.*
 
 * Free software: GPLv2 license
-* Documentation: https://pythonhosted.org/es-jsonschema/
+* Documentation: https://pythonhosted.org/domapping/

--- a/RELEASE-NOTES.rst
+++ b/RELEASE-NOTES.rst
@@ -1,13 +1,13 @@
-======================
- es-jsonschema v0.1.0
-======================
+==================
+ DoMapping v0.1.0
+==================
 
-es-jsonschema v0.1.0 was released on TBD, 2015.
+DoMapping v0.1.0 was released on January 21, 2016.
 
 About
 -----
 
-es-jsonschema provides a library and a CLI generating Elasticsearch mappings from json-schemas.
+DoMapping provides a library and a CLI generating Elasticsearch mappings from JSON Schemas.
 
 *This is an experimental developer preview release.*
 
@@ -19,18 +19,18 @@ What's new
 Installation
 ------------
 
-   $ pip install es-jsonschema==0.1.0
+   $ pip install domapping==0.1.0
 
 Documentation
 -------------
 
-   http://pythonhosted.org/es-jsonschema/
+   http://pythonhosted.org/domapping/
 
-Happy hacking and thanks for flying es-jsonschema.
+Happy hacking and thanks for flying DoMapping.
 
 | Invenio Development Team
 |   Email: info@invenio-software.org
 |   IRC: #invenio on irc.freenode.net
 |   Twitter: http://twitter.com/inveniosoftware
-|   GitHub: https://github.com/inveniosoftware/es-jsonschema
+|   GitHub: https://github.com/inveniosoftware/domapping
 |   URL: http://invenio-software.org

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -87,9 +87,9 @@ qthelp:
 	@echo
 	@echo "Build finished; now you can run "qcollectiongenerator" with the" \
 	      ".qhcp project file in $(BUILDDIR)/qthelp, like this:"
-	@echo "# qcollectiongenerator $(BUILDDIR)/qthelp/es-jsonschema.qhcp"
+	@echo "# qcollectiongenerator $(BUILDDIR)/qthelp/domapping.qhcp"
 	@echo "To view the help file:"
-	@echo "# assistant -collectionFile $(BUILDDIR)/qthelp/es-jsonschema.qhc"
+	@echo "# assistant -collectionFile $(BUILDDIR)/qthelp/domapping.qhc"
 
 applehelp:
 	$(SPHINXBUILD) -b applehelp $(ALLSPHINXOPTS) $(BUILDDIR)/applehelp
@@ -104,8 +104,8 @@ devhelp:
 	@echo
 	@echo "Build finished."
 	@echo "To view the help file:"
-	@echo "# mkdir -p $$HOME/.local/share/devhelp/es-jsonschema"
-	@echo "# ln -s $(BUILDDIR)/devhelp $$HOME/.local/share/devhelp/es-jsonschema"
+	@echo "# mkdir -p $$HOME/.local/share/devhelp/domapping"
+	@echo "# ln -s $(BUILDDIR)/devhelp $$HOME/.local/share/devhelp/domapping"
 	@echo "# devhelp"
 
 epub:

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,19 +1,19 @@
 ..
-    This file is part of es-jsonschema.
-    Copyright (C) 2015 CERN.
+    This file is part of DoMapping.
+    Copyright (C) 2015, 2016 CERN.
 
-    es-jsonschema is free software; you can redistribute it
+    DoMapping is free software; you can redistribute it
     and/or modify it under the terms of the GNU General Public License as
     published by the Free Software Foundation; either version 2 of the
     License, or (at your option) any later version.
 
-    es-jsonschema is distributed in the hope that it will be
+    DoMapping is distributed in the hope that it will be
     useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
     General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with es-jsonschema; if not, write to the
+    along with DoMapping; if not, write to the
     Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
     MA 02111-1307, USA.
 
@@ -25,6 +25,5 @@
 API Docs
 ========
 
-es_jsonschema
--------------
-
+domapping
+---------

--- a/docs/authors.rst
+++ b/docs/authors.rst
@@ -1,19 +1,19 @@
 ..
-    This file is part of es-jsonschema.
-    Copyright (C) 2015 CERN.
+    This file is part of DoMapping.
+    Copyright (C) 2015, 2016 CERN.
 
-    es-jsonschema is free software; you can redistribute it
+    DoMapping is free software; you can redistribute it
     and/or modify it under the terms of the GNU General Public License as
     published by the Free Software Foundation; either version 2 of the
     License, or (at your option) any later version.
 
-    es-jsonschema is distributed in the hope that it will be
+    DoMapping is distributed in the hope that it will be
     useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
     General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with es-jsonschema; if not, write to the
+    along with DoMapping; if not, write to the
     Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
     MA 02111-1307, USA.
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -1,19 +1,19 @@
 ..
-    This file is part of es-jsonschema.
-    Copyright (C) 2015 CERN.
+    This file is part of DoMapping.
+    Copyright (C) 2015, 2016 CERN.
 
-    es-jsonschema is free software; you can redistribute it
+    DoMapping is free software; you can redistribute it
     and/or modify it under the terms of the GNU General Public License as
     published by the Free Software Foundation; either version 2 of the
     License, or (at your option) any later version.
 
-    es-jsonschema is distributed in the hope that it will be
+    DoMapping is distributed in the hope that it will be
     useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
     General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with es-jsonschema; if not, write to the
+    along with DoMapping; if not, write to the
     Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
     MA 02111-1307, USA.
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-# This file is part of es-jsonschema.
-# Copyright (C) 2015 CERN.
+# This file is part of DoMapping.
+# Copyright (C) 2015, 2016 CERN.
 #
-# es-jsonschema is free software; you can redistribute it
+# DoMapping is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
 # published by the Free Software Foundation; either version 2 of the
 # License, or (at your option) any later version.
 #
-# es-jsonschema is distributed in the hope that it will be
+# DoMapping is distributed in the hope that it will be
 # useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 # General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with es-jsonschema; if not, write to the
+# along with DoMapping; if not, write to the
 # Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
 # MA 02111-1307, USA.
 #
@@ -69,7 +69,7 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'es-jsonschema'
+project = u'DoMapping'
 copyright = u'2015, CERN'
 author = u'CERN'
 
@@ -81,7 +81,7 @@ author = u'CERN'
 
 # Get the version string. Cannot be done with import!
 g = {}
-with open(os.path.join('..', 'es_jsonschema', 'version.py'), 'rt') as fp:
+with open(os.path.join('..', 'domapping', 'version.py'), 'rt') as fp:
     exec(fp.read(), g)
     version = g['__version__']
 
@@ -137,15 +137,15 @@ todo_include_todos = False
 html_theme = 'alabaster'
 
 html_theme_options = {
-    'description': 'es-jsonschema provides a library and a CLI generating Elasticsearch mappings from json-schemas.',
+    'description': 'DoMapping provides a library and a CLI generating Elasticsearch mappings from JSON Schemas.',
     'github_user': 'inveniosoftware',
-    'github_repo': 'es-jsonschema',
+    'github_repo': 'domapping',
     'github_button': False,
     'github_banner': True,
     'show_powered_by': False,
     'extra_nav_links': {
-        'es-jsonschema@GitHub': 'http://github.com/inveniosoftware/es-jsonschema',
-        'es-jsonschema@PyPI': 'http://pypi.python.org/pypi/es-jsonschema/',
+        'domapping@GitHub': 'http://github.com/inveniosoftware/domapping',
+        'domapping@PyPI': 'http://pypi.python.org/pypi/domapping/',
     }
 }
 
@@ -250,7 +250,7 @@ html_sidebars = {
 #html_search_scorer = 'scorer.js'
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = 'es-jsonschema_namedoc'
+htmlhelp_basename = 'domapping_namedoc'
 
 # -- Options for LaTeX output ---------------------------------------------
 
@@ -272,7 +272,7 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, 'es-jsonschema.tex', u'es-jsonschema Documentation',
+    (master_doc, 'domapping.tex', u'DoMapping Documentation',
      u'CERN', 'manual'),
 ]
 
@@ -302,7 +302,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    (master_doc, 'es-jsonschema', u'es-jsonschema Documentation',
+    (master_doc, 'DoMapping', u'DoMapping Documentation',
      [author], 1)
 ]
 
@@ -316,8 +316,8 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, 'es-jsonschema', u'es-jsonschema Documentation',
-     author, 'es-jsonschema', 'es-jsonschema provides a library and a CLI generating Elasticsearch mappings from json-schemas.',
+    (master_doc, 'DoMapping', u'DoMapping Documentation',
+     author, 'DoMapping', 'DoMapping provides a library and a CLI generating Elasticsearch mappings from JSON Schemas.',
      'Miscellaneous'),
 ]
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -1,19 +1,19 @@
 ..
-    This file is part of es-jsonschema.
-    Copyright (C) 2015 CERN.
+    This file is part of DoMapping.
+    Copyright (C) 2015, 2016 CERN.
 
-    es-jsonschema is free software; you can redistribute it
+    DoMapping is free software; you can redistribute it
     and/or modify it under the terms of the GNU General Public License as
     published by the Free Software Foundation; either version 2 of the
     License, or (at your option) any later version.
 
-    es-jsonschema is distributed in the hope that it will be
+    DoMapping is distributed in the hope that it will be
     useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
     General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with es-jsonschema; if not, write to the
+    along with DoMapping; if not, write to the
     Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
     MA 02111-1307, USA.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,19 +1,19 @@
 ..
-    This file is part of es-jsonschema.
-    Copyright (C) 2015 CERN.
+    This file is part of DoMapping.
+    Copyright (C) 2015, 2016 CERN.
 
-    es-jsonschema is free software; you can redistribute it
+    DoMapping is free software; you can redistribute it
     and/or modify it under the terms of the GNU General Public License as
     published by the Free Software Foundation; either version 2 of the
     License, or (at your option) any later version.
 
-    es-jsonschema is distributed in the hope that it will be
+    DoMapping is distributed in the hope that it will be
     useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
     General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with es-jsonschema; if not, write to the
+    along with DoMapping; if not, write to the
     Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
     MA 02111-1307, USA.
 
@@ -28,7 +28,7 @@ User's Guide
 ------------
 
 This part of the documentation will show you how to get started in using
-Invenio-Base.
+DoMapping.
 
 .. toctree::
    :maxdepth: 2

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1,19 +1,19 @@
 ..
-    This file is part of es-jsonschema.
-    Copyright (C) 2015 CERN.
+    This file is part of DoMapping.
+    Copyright (C) 2015, 2016 CERN.
 
-    es-jsonschema is free software; you can redistribute it
+    DoMapping is free software; you can redistribute it
     and/or modify it under the terms of the GNU General Public License as
     published by the Free Software Foundation; either version 2 of the
     License, or (at your option) any later version.
 
-    es-jsonschema is distributed in the hope that it will be
+    DoMapping is distributed in the hope that it will be
     useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
     General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with es-jsonschema; if not, write to the
+    along with DoMapping; if not, write to the
     Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
     MA 02111-1307, USA.
 

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -127,9 +127,9 @@ if "%1" == "qthelp" (
 	echo.
 	echo.Build finished; now you can run "qcollectiongenerator" with the ^
 .qhcp project file in %BUILDDIR%/qthelp, like this:
-	echo.^> qcollectiongenerator %BUILDDIR%\qthelp\es-jsonschema.qhcp
+  echo.^> qcollectiongenerator %BUILDDIR%\qthelp\domapping.qhcp
 	echo.To view the help file:
-	echo.^> assistant -collectionFile %BUILDDIR%\qthelp\es-jsonschema.ghc
+  echo.^> assistant -collectionFile %BUILDDIR%\qthelp\domapping.ghc
 	goto end
 )
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -1,19 +1,19 @@
 ..
-    This file is part of es-jsonschema.
-    Copyright (C) 2015 CERN.
+    This file is part of DoMapping.
+    Copyright (C) 2015, 2016 CERN.
 
-    es-jsonschema is free software; you can redistribute it
+    DoMapping is free software; you can redistribute it
     and/or modify it under the terms of the GNU General Public License as
     published by the Free Software Foundation; either version 2 of the
     License, or (at your option) any later version.
 
-    es-jsonschema is distributed in the hope that it will be
+    DoMapping is distributed in the hope that it will be
     useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
     General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with es-jsonschema; if not, write to the
+    along with DoMapping; if not, write to the
     Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
     MA 02111-1307, USA.
 
@@ -26,4 +26,4 @@
  Usage
 =======
 
-.. automodule:: es_jsonschema
+.. automodule:: domapping

--- a/domapping/__init__.py
+++ b/domapping/__init__.py
@@ -1,25 +1,25 @@
 # -*- coding: utf-8 -*-
 #
-# This file is part of es-jsonschema.
-# Copyright (C) 2015 CERN.
+# This file is part of DoMapping.
+# Copyright (C) 2015, 2016 CERN.
 #
-# es-jsonschema is free software; you can redistribute it and/or
+# DoMapping is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
 # published by the Free Software Foundation; either version 2 of the
 # License, or (at your option) any later version.
 #
-# es-jsonschema is distributed in the hope that it will be
+# DoMapping is distributed in the hope that it will be
 # useful, but
 # WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 # General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with es-jsonschema; if not, write to the Free Software
+# along with DoMapping; if not, write to the Free Software
 # Foundation, Inc.,
 # 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 
-"""es-jsonschema generates Elasticsearch mappings from json-schemas."""
+"""DoMapping generates Elasticsearch mappings from JSON Schemas."""
 
 from __future__ import absolute_import, print_function
 

--- a/domapping/cli.py
+++ b/domapping/cli.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-# This file is part of es-jsonschema.
-# Copyright (C) 2015 CERN.
+# This file is part of DoMapping.
+# Copyright (C) 2015, 2016 CERN.
 #
-# es-jsonschema is free software; you can redistribute it
+# DoMapping is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
 # published by the Free Software Foundation; either version 2 of the
 # License, or (at your option) any later version.
 #
-# es-jsonschema is distributed in the hope that it will be
+# DoMapping is distributed in the hope that it will be
 # useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 # General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with es-jsonschema; if not, write to the
+# along with DoMapping; if not, write to the
 # Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
 # MA 02111-1307, USA.
 #
@@ -48,11 +48,11 @@ def cli():
 @click.option('--indent', '-i', default=4, type=click.INT,
               help='Output json indentation step.')
 def schema_to_mapping_cli(schema, output, config, indent):
-    """Generate Elasticsearch mapping from json-schema."""
+    """Generate Elasticsearch mapping from JSON Schema."""
     parsed_schema = json.load(schema)
 
     if 'id' not in parsed_schema and not hasattr(schema, 'name'):
-        raise JsonSchemaSupportError('json-schema does not contain any '
+        raise JsonSchemaSupportError('JSON Schema does not contain any '
                                      '\'id\' field and input has no name',
                                      '<INPUT>')
     id = parsed_schema.get('id',

--- a/domapping/errors.py
+++ b/domapping/errors.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-# This file is part of es-jsonschema.
-# Copyright (C) 2015 CERN.
+# This file is part of DoMapping.
+# Copyright (C) 2015, 2016 CERN.
 #
-# es-jsonschema is free software; you can redistribute it
+# DoMapping is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
 # published by the Free Software Foundation; either version 2 of the
 # License, or (at your option) any later version.
 #
-# es-jsonschema is distributed in the hope that it will be
+# DoMapping is distributed in the hope that it will be
 # useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 # General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with es-jsonschema; if not, write to the
+# along with DoMapping; if not, write to the
 # Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
 # MA 02111-1307, USA.
 #

--- a/domapping/mapping.py
+++ b/domapping/mapping.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-# This file is part of es-jsonschema.
-# Copyright (C) 2015 CERN.
+# This file is part of DoMapping.
+# Copyright (C) 2015, 2016 CERN.
 #
-# es-jsonschema is free software; you can redistribute it
+# DoMapping is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
 # published by the Free Software Foundation; either version 2 of the
 # License, or (at your option) any later version.
 #
-# es-jsonschema is distributed in the hope that it will be
+# DoMapping is distributed in the hope that it will be
 # useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 # General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with es-jsonschema; if not, write to the
+# along with DoMapping; if not, write to the
 # Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
 # MA 02111-1307, USA.
 #
@@ -64,8 +64,8 @@ class ElasticMappingGeneratorConfig(object):
                 # type mappings with parameters for py:meth:`map_type`
                 'types': [{
                     'es_type': 'elasticsearch type',
-                    'json_type': 'json-schema type',
-                    'json_format': 'json-schema format',
+                    'json_type': 'JSON Schema type',
+                    'json_format': 'JSON Schema format',
                     'es_props': {
                         # additional elasticsearch properties
                     },

--- a/domapping/templating.py
+++ b/domapping/templating.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-# This file is part of es-jsonschema.
-# Copyright (C) 2015 CERN.
+# This file is part of DoMapping.
+# Copyright (C) 2015, 2016 CERN.
 #
-# es-jsonschema is free software; you can redistribute it
+# DoMapping is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
 # published by the Free Software Foundation; either version 2 of the
 # License, or (at your option) any later version.
 #
-# es-jsonschema is distributed in the hope that it will be
+# DoMapping is distributed in the hope that it will be
 # useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 # General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with es-jsonschema; if not, write to the
+# along with DoMapping; if not, write to the
 # Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
 # MA 02111-1307, USA.
 #

--- a/domapping/version.py
+++ b/domapping/version.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-# This file is part of es-jsonschema.
-# Copyright (C) 2015 CERN.
+# This file is part of DoMapping.
+# Copyright (C) 2015, 2016 CERN.
 #
-# es-jsonschema is free software; you can redistribute it
+# DoMapping is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
 # published by the Free Software Foundation; either version 2 of the
 # License, or (at your option) any later version.
 #
-# es-jsonschema is distributed in the hope that it will be
+# DoMapping is distributed in the hope that it will be
 # useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 # General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with es-jsonschema; if not, write to the
+# along with DoMapping; if not, write to the
 # Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
 # MA 02111-1307, USA.
 #
@@ -22,9 +22,9 @@
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
-"""Version information for es-jsonschema.
+"""Version information for domapping.
 
-This file is imported by ``es_jsonschema.__init__``,
+This file is imported by ``domapping.__init__``,
 and parsed by ``setup.py``.
 """
 

--- a/examples/app.py
+++ b/examples/app.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-# This file is part of es-jsonschema.
-# Copyright (C) 2015 CERN.
+# This file is part of DoMapping.
+# Copyright (C) 2015, 2016 CERN.
 #
-# es-jsonschema is free software; you can redistribute it
+# DoMapping is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
 # published by the Free Software Foundation; either version 2 of the
 # License, or (at your option) any later version.
 #
-# es-jsonschema is distributed in the hope that it will be
+# DoMapping is distributed in the hope that it will be
 # useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 # General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with es-jsonschema; if not, write to the
+# along with DoMapping; if not, write to the
 # Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
 # MA 02111-1307, USA.
 #
@@ -38,9 +38,9 @@ The same result could be created with the cli:
 
     $ cd examples
     $ mkdir generated
-    $ esjsonschema schema_to_mapping schema.json --config config.json | \
-        esjsonschema mapping_to_jinja > generated/generated_schema.json
-    $ esjsonschema jinja_to_mapping template.json --context_path generated
+    $ domapping schema_to_mapping schema.json --config config.json | \
+        domapping mapping_to_jinja > generated/generated_schema.json
+    $ domapping jinja_to_mapping template.json --context_path generated
 """
 
 from __future__ import absolute_import, print_function
@@ -48,9 +48,8 @@ from __future__ import absolute_import, print_function
 import json
 import os
 
-from es_jsonschema.mapping import ElasticMappingGeneratorConfig, \
-    schema_to_mapping
-from es_jsonschema.templating import jinja_to_mapping, mapping_to_jinja
+from domapping.mapping import ElasticMappingGeneratorConfig, schema_to_mapping
+from domapping.templating import jinja_to_mapping, mapping_to_jinja
 
 config = ElasticMappingGeneratorConfig()
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-# This file is part of es-jsonschema.
-# Copyright (C) 2015 CERN.
+# This file is part of DoMapping.
+# Copyright (C) 2015, 2016 CERN.
 #
-# es-jsonschema is free software; you can redistribute it
+# DoMapping is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
 # published by the Free Software Foundation; either version 2 of the
 # License, or (at your option) any later version.
 #
-# es-jsonschema is distributed in the hope that it will be
+# DoMapping is distributed in the hope that it will be
 # useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 # General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with es-jsonschema; if not, write to the
+# along with DoMapping; if not, write to the
 # Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
 # MA 02111-1307, USA.
 #
@@ -23,4 +23,4 @@
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
 [pytest]
-addopts = --pep8 --ignore=docs --cov=es_jsonschema --cov-report=term-missing
+addopts = --pep8 --ignore=docs --cov=domapping --cov-report=term-missing

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-# This file is part of es-jsonschema.
-# Copyright (C) 2015 CERN.
+# This file is part of DoMapping.
+# Copyright (C) 2015, 2016 CERN.
 #
-# es-jsonschema is free software; you can redistribute it
+# DoMapping is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
 # published by the Free Software Foundation; either version 2 of the
 # License, or (at your option) any later version.
 #
-# es-jsonschema is distributed in the hope that it will be
+# DoMapping is distributed in the hope that it will be
 # useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 # General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with es-jsonschema; if not, write to the
+# along with DoMapping; if not, write to the
 # Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
 # MA 02111-1307, USA.
 #

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-# This file is part of es-jsonschema.
-# Copyright (C) 2015 CERN.
+# This file is part of DoMapping.
+# Copyright (C) 2015, 2016 CERN.
 #
-# es-jsonschema is free software; you can redistribute it
+# DoMapping is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
 # published by the Free Software Foundation; either version 2 of the
 # License, or (at your option) any later version.
 #
-# es-jsonschema is distributed in the hope that it will be
+# DoMapping is distributed in the hope that it will be
 # useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 # General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with es-jsonschema; if not, write to the
+# along with DoMapping; if not, write to the
 # Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
 # MA 02111-1307, USA.
 #
@@ -23,7 +23,7 @@
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
 
-pep257 es_jsonschema && \
+pep257 domapping && \
 isort -rc -c -df **/*.py && \
 check-manifest --ignore ".travis-*" && \
 sphinx-build -qnNW docs docs/_build/html && \

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-# This file is part of es-jsonschema.
-# Copyright (C) 2015 CERN.
+# This file is part of DoMapping.
+# Copyright (C) 2015, 2016 CERN.
 #
-# es-jsonschema is free software; you can redistribute it
+# DoMapping is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
 # published by the Free Software Foundation; either version 2 of the
 # License, or (at your option) any later version.
 #
-# es-jsonschema is distributed in the hope that it will be
+# DoMapping is distributed in the hope that it will be
 # useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 # General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with es-jsonschema; if not, write to the
+# along with DoMapping; if not, write to the
 # Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
 # MA 02111-1307, USA.
 #

--- a/setup.py
+++ b/setup.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-# This file is part of es-jsonschema.
-# Copyright (C) 2015 CERN.
+# This file is part of DoMapping.
+# Copyright (C) 2015, 2016 CERN.
 #
-# es-jsonschema is free software; you can redistribute it
+# DoMapping is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
 # published by the Free Software Foundation; either version 2 of the
 # License, or (at your option) any later version.
 #
-# es-jsonschema is distributed in the hope that it will be
+# DoMapping is distributed in the hope that it will be
 # useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 # General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with es-jsonschema; if not, write to the
+# along with DoMapping; if not, write to the
 # Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
 # MA 02111-1307, USA.
 #
@@ -22,7 +22,7 @@
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
-"""es-jsonschema generates Elasticsearch mappings from json-schemas."""
+"""DoMapping generates Elasticsearch mappings from JSON Schemas."""
 
 import os
 import sys
@@ -103,12 +103,12 @@ class PyTest(TestCommand):
 
 # Get the version string. Cannot be done with import!
 g = {}
-with open(os.path.join('es_jsonschema', 'version.py'), 'rt') as fp:
+with open(os.path.join('domapping', 'version.py'), 'rt') as fp:
     exec(fp.read(), g)
     version = g['__version__']
 
 setup(
-    name='es-jsonschema',
+    name='domapping',
     version=version,
     description=__doc__,
     long_description=readme + '\n\n' + history,
@@ -116,14 +116,14 @@ setup(
     license='GPLv2',
     author='CERN',
     author_email='info@invenio-software.org',
-    url='https://github.com/inveniosoftware/es-jsonschema',
+    url='https://github.com/inveniosoftware/domapping',
     packages=packages,
     zip_safe=False,
     include_package_data=True,
     platforms='any',
     entry_points={
         'console_scripts': [
-            'esjsonschema = es_jsonschema.cli:cli',
+            'domapping = domapping.cli:cli',
         ],
     },
     extras_require=extras_require,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-# This file is part of es-jsonschema.
-# Copyright (C) 2015 CERN.
+# This file is part of DoMapping.
+# Copyright (C) 2015, 2016 CERN.
 #
-# es-jsonschema is free software; you can redistribute it
+# DoMapping is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
 # published by the Free Software Foundation; either version 2 of the
 # License, or (at your option) any later version.
 #
-# es-jsonschema is distributed in the hope that it will be
+# DoMapping is distributed in the hope that it will be
 # useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 # General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with es-jsonschema; if not, write to the
+# along with DoMapping; if not, write to the
 # Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
 # MA 02111-1307, USA.
 #
@@ -22,7 +22,7 @@
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
-"""Tests of es_jsonschema.cli."""
+"""Tests of domapping.cli."""
 
 import copy
 import json
@@ -33,9 +33,9 @@ import traceback
 import jinja2
 from click.testing import CliRunner
 
-from es_jsonschema.cli import jinja_to_mapping_cli, mapping_to_jinja_cli, \
+from domapping.cli import jinja_to_mapping_cli, mapping_to_jinja_cli, \
     schema_to_mapping_cli
-from es_jsonschema.errors import JsonSchemaSupportError
+from domapping.errors import JsonSchemaSupportError
 
 
 def assert_no_exception(result):

--- a/tests/test_generate_mapping.py
+++ b/tests/test_generate_mapping.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-# This file is part of es-jsonschema.
-# Copyright (C) 2015 CERN.
+# This file is part of DoMapping.
+# Copyright (C) 2015, 2016 CERN.
 #
-# es-jsonschema is free software; you can redistribute it
+# DoMapping is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
 # published by the Free Software Foundation; either version 2 of the
 # License, or (at your option) any later version.
 #
-# es-jsonschema is distributed in the hope that it will be
+# DoMapping is distributed in the hope that it will be
 # useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 # General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with es-jsonschema; if not, write to the
+# along with DoMapping; if not, write to the
 # Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
 # MA 02111-1307, USA.
 #
@@ -26,9 +26,8 @@
 
 import pytest
 
-from es_jsonschema.errors import JsonSchemaSupportError
-from es_jsonschema.mapping import ElasticMappingGeneratorConfig, \
-    schema_to_mapping
+from domapping.errors import JsonSchemaSupportError
+from domapping.mapping import ElasticMappingGeneratorConfig, schema_to_mapping
 
 
 def test_simple_properties():

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-# This file is part of es-jsonschema.
-# Copyright (C) 2015 CERN.
+# This file is part of DoMapping.
+# Copyright (C) 2015, 2016 CERN.
 #
-# es-jsonschema is free software; you can redistribute it
+# DoMapping is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
 # published by the Free Software Foundation; either version 2 of the
 # License, or (at your option) any later version.
 #
-# es-jsonschema is distributed in the hope that it will be
+# DoMapping is distributed in the hope that it will be
 # useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 # General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with es-jsonschema; if not, write to the
+# along with DoMapping; if not, write to the
 # Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
 # MA 02111-1307, USA.
 #
@@ -27,5 +27,5 @@
 
 def test_version():
     """Test version import."""
-    from es_jsonschema import __version__
+    from domapping import __version__
     assert __version__

--- a/tests/test_templating.py
+++ b/tests/test_templating.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 #
-# This file is part of es-jsonschema.
-# Copyright (C) 2015 CERN.
+# This file is part of DoMapping.
+# Copyright (C) 2015, 2016 CERN.
 #
-# es-jsonschema is free software; you can redistribute it
+# DoMapping is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
 # published by the Free Software Foundation; either version 2 of the
 # License, or (at your option) any later version.
 #
-# es-jsonschema is distributed in the hope that it will be
+# DoMapping is distributed in the hope that it will be
 # useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 # General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with es-jsonschema; if not, write to the
+# along with DoMapping; if not, write to the
 # Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
 # MA 02111-1307, USA.
 #
@@ -28,7 +28,7 @@ import json
 
 import jinja2
 
-from es_jsonschema.templating import mapping_to_jinja
+from domapping.templating import mapping_to_jinja
 
 
 def test_json_validity():


### PR DESCRIPTION
- Changes human-friendly package name to `DoMapping` and Python package
  name to `domapping`.

Signed-off-by: Tibor Simko tibor.simko@cern.ch
