### PR TITLE
cli: addition of `mapping_type` parameter

### DIFF
--- a/domapping/templating.py
+++ b/domapping/templating.py
@@ -32,18 +32,19 @@ from six import iteritems
 from .mapping import clean_mapping
 
 
-def mapping_to_jinja(es_mapping, type_name, indent=2):
+def mapping_to_jinja(es_mapping, type_name, indent=2, start_indent=''):
     """Pretty pring an elasticsearch type mapping as a jinja template.
 
     :param es_mapping: elasticsearch mapping
     :param type_name: name of the elasticsearch type
     :param indent: intentation step
+    :param start_indent: base indent
     """
     result = []
     result += '{{\n'.format(type=type_name)
     result += _mapping_to_jinja_rec(es_mapping, type_name, indent,
-                                    ' ' * indent)
-    result += '}'
+                                    start_indent + ' ' * indent)
+    result += start_indent + '}'
     return ''.join(result)
 
 


### PR DESCRIPTION
- Adds a new parameter (`mapping_type`) that allows you to generate
  mappings to use directly with `invenio_search.mappings` entry point.
  (closes #9)

Signed-off-by: Javier Delgado javier.delgado.fernandez@cern.ch
