### PR TITLE
tests: run-tests.sh shebang fix

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env sh
 # -*- coding: utf-8 -*-
 #
 # This file is part of DoMapping.


### PR DESCRIPTION
- Adds the shebang to run-tests.sh.

Signed-off-by: Nicolas Harraudeau nicolas.harraudeau@cern.ch
Co-authored-by: Javier Delgado javier.delgado.fernandez@cern.ch

As spotted by @JavierDelgadoFernandez in #12.
