### PR TITLE
mapping: enable to enabled

### DIFF
--- a/domapping/mapping.py
+++ b/domapping/mapping.py
@@ -148,7 +148,7 @@ def schema_to_mapping(json_schema, base_uri, context_schemas, config):
                                       store=context_schemas,
                                       base_uri=base_uri)
     return _gen_type_properties(json_schema, base_uri, resolver, config, {
-        '_all': {'enable': config.all_field},
+        '_all': {'enabled': config.all_field},
         'numeric_detection': config.numeric_detection,
         'date_detection': config.date_detection,
         # empty type mapping

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -61,7 +61,7 @@ def assert_no_exception(result):
 
 expected_mapping = {
     "_all": {
-        "enable": False,
+        "enabled": False,
     },
     "numeric_detection": False,
     "properties": {
@@ -286,7 +286,7 @@ def test_mapping_to_jinja():
     """Test mapping_to_jinja."""
     mapping = {
         "_all": {
-            "enable": False,
+            "enabled": False,
         },
         "numeric_detection": False,
         "properties": {
@@ -513,7 +513,7 @@ def test_mapping_to_jinja_wo_type():
     """
     mapping = {
         "_all": {
-            "enable": False,
+            "enabled": False,
         },
         "numeric_detection": False,
         "properties": {

--- a/tests/test_generate_mapping.py
+++ b/tests/test_generate_mapping.py
@@ -47,7 +47,7 @@ def test_simple_properties():
         },
     }
     es_mapping = {
-        '_all': {'enable': True},
+        '_all': {'enabled': True},
         'numeric_detection': True,
         'date_detection': True,
         'properties': {
@@ -96,7 +96,7 @@ def test_references():
         },
     }
     es_mapping = {
-        '_all': {'enable': True},
+        '_all': {'enabled': True},
         'numeric_detection': True,
         'date_detection': True,
         'properties': {
@@ -167,7 +167,7 @@ def test_allOf_anyOf_oneOf():
         }]
     }
     es_mapping = {
-        '_all': {'enable': True},
+        '_all': {'enabled': True},
         'numeric_detection': True,
         'date_detection': True,
         'properties': {
@@ -234,7 +234,7 @@ def test_complex_array():
         },
     }
     es_mapping = {
-        '_all': {'enable': True},
+        '_all': {'enabled': True},
         'numeric_detection': True,
         'date_detection': True,
         'properties': {
@@ -277,7 +277,7 @@ def test_depencency_extension():
         }
     }
     es_mapping = {
-        '_all': {'enable': True},
+        '_all': {'enabled': True},
         'numeric_detection': True,
         'date_detection': True,
         'properties': {
@@ -302,7 +302,7 @@ def test_type_mapping():
         },
     }
     es_mapping = {
-        '_all': {'enable': True},
+        '_all': {'enabled': True},
         'numeric_detection': True,
         'date_detection': True,
         'properties': {
@@ -364,7 +364,7 @@ def test_additionnalproperties_value_to_false():
         "additionalProperties": False
     }
     es_mapping = {
-        '_all': {'enable': True},
+        '_all': {'enabled': True},
         'numeric_detection': True,
         'date_detection': True,
         'properties': {


### PR DESCRIPTION
The use of the `_all` field can be toggled with the `enabled` property, not `enable`. See: https://www.elastic.co/guide/en/elasticsearch/reference/2.4/mapping-all-field.html#disabling-all-field.