### PR TITLE
global: build fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of DoMapping.
-# Copyright (C) 2015, 2016 CERN.
+# Copyright (C) 2015, 2016, 2017 CERN.
 #
 # DoMapping is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -40,8 +40,6 @@ env:
 
 python:
   - "2.7"
-  - "3.3"
-  - "3.4"
   - "3.5"
 
 before_install:

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of DoMapping.
-# Copyright (C) 2015, 2016 CERN.
+# Copyright (C) 2015, 2016, 2017 CERN.
 #
 # DoMapping is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -61,7 +61,7 @@ setup_requires = [
 
 install_requires = [
     'jsonschema>=2.5.0',
-    'six>=1.7.2',
+    'six>=1.9',
     'Jinja2>=2.7',
     'click>=5.1',
 ]


### PR DESCRIPTION
As https://travis-ci.org/inveniosoftware/domapping/builds/209486851 shows, build is currently failing. This PR should fix it by:

* Requiring `six>=1.9`
* Removing support for Python 3.3 and Python 3.4